### PR TITLE
fix: indexer cli arg parse within pruneindex.js

### DIFF
--- a/Indexer/README.md
+++ b/Indexer/README.md
@@ -16,7 +16,7 @@ the number of unique words.
 
 Example
 ```
-node indexer /var/myrepo md
+node indexer.js /var/myrepo md
 ```
 
 This process creates two files in current directory:
@@ -29,13 +29,13 @@ they are not add something to the search process. You
 can prune the words using:
 
 ```
-rm pruned.json`
-node pruneindex [options...]
+rm pruned.json
+node pruneindex.js [options...]
 ```
 
 Examples:
 ```
-rm pruned.json`
+rm pruned.json
 node pruneindex --minlen 3 --maxcount 300
 ```
 
@@ -44,9 +44,9 @@ than 3 AND no of pages equal or greater than 300
 
 Another example:
 ```
-rm pruned.json`
-node pruneindex --minlen 2
-node pruneindex  --maxcount 200
+rm pruned.json
+node pruneindex.js --minlen 2
+node pruneindex.js --maxcount 200
 ```
 
 In this case, these commands remove the words with length equal or less
@@ -54,10 +54,10 @@ than 2 OR no of pages equal or greater than 200.
 
 Exaple using subword:
 ```
-rm pruned.json`
-node pruneindex --subword block --maxcount 200
+rm pruned.json
+node pruneindex.js --subword block --maxcount 200
 ```
-The above command remove the words with no of pages equal or 
+The above command remove the words with no of pages equal or
 greater than 200 AND containing the subword `block`.
 
 
@@ -77,7 +77,7 @@ Example, if that file contains:
 
 the prune command:
 ```
-node pruneindex -ml 3
+node pruneindex.js -ml 3
 ```
 
 DONT REMOVE the words `tdd` nor `ddd`.
@@ -88,7 +88,7 @@ DONT REMOVE the words `tdd` nor `ddd`.
 Using the command
 
 ```
-node listindex [options...]
+node listindex.js [options...]
 ```
 
 It list the words in the created index sorted by descending
@@ -103,10 +103,10 @@ equal to `<value>`.
 
 Examples
 ```
-node listindex
-node listindex -mc 200
-node listindex -ml 3 -mc 150
-node listindex -s block
+node listindex.js
+node listindex.js -mc 200
+node listindex.js -ml 3 -mc 150
+node listindex.js -s block
 
 ```
 
@@ -115,12 +115,12 @@ node listindex -s block
 
 Search the files with:
 ```
-node search <words>...
+node search.js <words>...
 ```
 
 Example
 ```
-node search block transaction
+node search.js block transaction
 ```
 
 The list of files containing ALL the words will be listed.
@@ -134,4 +134,3 @@ The first ones have more occurrences of the words combination
 - [Array.prototype.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
 - [Multiline strings in ES6 JavaScript](https://jack.ofspades.com/multiline-strings-in-es6-javascript/)
 - [Improvements by bguiz](https://github.com/bguiz/JavaScriptSamples/blob/feat/bguiz-indexer-improvements/Indexer/README.md)
-

--- a/Indexer/pruneindex.js
+++ b/Indexer/pruneindex.js
@@ -20,58 +20,62 @@ catch (ex) {
     included = [];
 }
 
-simpleargs.define('ml','maxlen',0,'Maximum Length');
-simpleargs.define('mc','mincount',0,'Minimum Count');
-simpleargs.define('s','subword',0,'Subword');
+simpleargs.define('ml','minlen',0,'Minimum Length');
+simpleargs.define('mc','maxcount',0,'Maximum Count');
+simpleargs.define('s','subword','','Subword');
 
 const args = simpleargs(process.argv.slice(2));
 
-const maxlen = args.maxlen;
-const mincount = args.mincount;
+const minlen = args.minlen;
+const maxcount = args.maxcount;
 const subword = args.subword;
-    
+
+const hasMinlen = typeof minlen === 'number' && minlen > 0;
+const hasMaxcount = typeof maxcount === 'number' && maxcount > 0;
+const hasSubword = typeof subword === 'string' && subword.length > 0;
+
 const newindex = {};
 
 for (let word in index) {
-    if (subword && word.indexOf(subword) < 0) {
+    if (hasSubword && word.indexOf(subword) < 0) {
         newindex[word] = index[word];
-        
+
         continue;
     }
-        
+
     if (included.indexOf(word) >= 0) {
         newindex[word] = index[word];
-        
+
         continue;
     }
-        
-    if (maxlen && word.length <= maxlen) {
+
+    if (hasMinlen && word.length <= minlen) {
         toPrune(word);
 
         continue;
     }
-        
+
     const data = index[word];
     const npages = Object.keys(data).length;
-    
-    if (mincount && npages >= mincount) {
+
+    if (hasMaxcount && npages >= maxcount) {
         toPrune(word);
 
         continue;
     }
-        
+
     newindex[word] = index[word];
 }
 
 function toPrune(word) {
     console.log('pruning', word);
-    
+
     if (pruned.indexOf(word) >= 0)
         return;
-        
+
     pruned.push(word);
 }
 
 fs.writeFileSync('./pruned.json', JSON.stringify(pruned));
-    
+
 fs.writeFileSync('./index.json', JSON.stringify(newindex));


### PR DESCRIPTION
## What

- parsing of minlen and maxcount cli args in `pruneindex.js`
  - previously had 'min' and 'max' swapped in the names for those 2 variables
  - added better detection of whether args were specified and therefore should be used for filtering
- readme: removed extra backticks, and added `.js`

## Why

- impl didn't match readme for usage of `pruneindex.js` (names of cli args mismatch)

## Refs

- nil
- NOTE: No tests were added, TODO
