### PR TITLE
feat: newline tags and outer quotes

### DIFF
--- a/Indexer/README.md
+++ b/Indexer/README.md
@@ -16,7 +16,7 @@ the number of unique words.
 
 Example
 ```
-node indexer /var/myrepo md
+node indexer.js /var/myrepo md
 ```
 
 This process creates two files in current directory:
@@ -29,13 +29,13 @@ they are not add something to the search process. You
 can prune the words using:
 
 ```
-rm pruned.json`
-node pruneindex [options...]
+rm pruned.json
+node pruneindex.js [options...]
 ```
 
 Examples:
 ```
-rm pruned.json`
+rm pruned.json
 node pruneindex --minlen 3 --maxcount 300
 ```
 
@@ -44,9 +44,9 @@ than 3 AND no of pages equal or greater than 300
 
 Another example:
 ```
-rm pruned.json`
-node pruneindex --minlen 2
-node pruneindex  --maxcount 200
+rm pruned.json
+node pruneindex.js --minlen 2
+node pruneindex.js --maxcount 200
 ```
 
 In this case, these commands remove the words with length equal or less
@@ -54,10 +54,10 @@ than 2 OR no of pages equal or greater than 200.
 
 Exaple using subword:
 ```
-rm pruned.json`
-node pruneindex --subword block --maxcount 200
+rm pruned.json
+node pruneindex.js --subword block --maxcount 200
 ```
-The above command remove the words with no of pages equal or 
+The above command remove the words with no of pages equal or
 greater than 200 AND containing the subword `block`.
 
 
@@ -77,7 +77,7 @@ Example, if that file contains:
 
 the prune command:
 ```
-node pruneindex -ml 3
+node pruneindex.js -ml 3
 ```
 
 DONT REMOVE the words `tdd` nor `ddd`.
@@ -88,7 +88,7 @@ DONT REMOVE the words `tdd` nor `ddd`.
 Using the command
 
 ```
-node listindex [options...]
+node listindex.js [options...]
 ```
 
 It list the words in the created index sorted by descending
@@ -103,10 +103,10 @@ equal to `<value>`.
 
 Examples
 ```
-node listindex
-node listindex -mc 200
-node listindex -ml 3 -mc 150
-node listindex -s block
+node listindex.js
+node listindex.js -mc 200
+node listindex.js -ml 3 -mc 150
+node listindex.js -s block
 
 ```
 
@@ -115,12 +115,12 @@ node listindex -s block
 
 Search the files with:
 ```
-node search <words>...
+node search.js <words>...
 ```
 
 Example
 ```
-node search block transaction
+node search.js block transaction
 ```
 
 The list of files containing ALL the words will be listed.
@@ -134,4 +134,3 @@ The first ones have more occurrences of the words combination
 - [Array.prototype.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
 - [Multiline strings in ES6 JavaScript](https://jack.ofspades.com/multiline-strings-in-es6-javascript/)
 - [Improvements by bguiz](https://github.com/bguiz/JavaScriptSamples/blob/feat/bguiz-indexer-improvements/Indexer/README.md)
-

--- a/Indexer/indexer.js
+++ b/Indexer/indexer.js
@@ -3,6 +3,7 @@ const path = require('path');
 const simpleargs = require('simpleargs');
 
 simpleargs.define('w','weighted',false,'Weighted Word Count', { flag: true });
+simpleargs.define('sd','subdirs','','Sub directories to include');
 
 const words = require('./lib/words');
 const files = require('./lib/files');
@@ -12,47 +13,52 @@ const args = simpleargs(process.argv.slice(2));
 
 const dirpath = args._[0];
 const extension = '.' + args._[1];
+const subdirsArg = args.subdirs;
+const hasSubdirsArg = typeof subdirsArg === 'string' && subdirsArg.length > 0;
+const subdirs = (hasSubdirsArg) ?
+    subdirsArg.split(':') :
+    [];
 
 const filesdes = [];
 const result = {};
 
-files.processFiles(dirpath, extension, null, 
+files.processFiles(dirpath, extension, null, subdirs,
     filename => {
         const filepath = path.join(dirpath, filename);
         const text = fs.readFileSync(filepath).toString();
-        
+
         const title = markdown.getTitle(text);
         const summary = markdown.getSummary(text);
         const description = markdown.getDescription(text);
         const header = markdown.getHeader(text);
         const tags = markdown.getTags(text);
         const permalink = markdown.getPermalink(text);
-        
+
         const file = { n: filename };
-        
+
         if (title)
             file.t = title;
         else if (header)
             file.t = header;
-        
+
         if (summary)
             file.d = summary;
         else if (description)
             file.d = description;
-            
+
         if (tags)
             if (file.d)
                 file.d += ' ' + tags;
             else
                 file.d = tags;
-                
+
         if (permalink)
             file.l = permalink;
-            
+
         filesdes.push(file);
-        
+
         const cwords = words.countWords(words.toWords(text), args.weighted);
-        
+
         words.collectWords(result, cwords, filesdes.length - 1);
     });
 

--- a/Indexer/indexer.js
+++ b/Indexer/indexer.js
@@ -40,17 +40,18 @@ files.processFiles(dirpath, extension, null, subdirs,
             file.t = title;
         else if (header)
             file.t = header;
+        file.t = stripOuterQuotes(file.t);
 
         if (summary)
             file.d = summary;
         else if (description)
             file.d = description;
+        file.d = stripOuterQuotes(file.d);
+        if (file.d)
+            file.d.replace(/\n/g, ' ');
 
         if (tags)
-            if (file.d)
-                file.d += ' ' + tags;
-            else
-                file.d = tags;
+            file.d = (file.d || '') + '\n' + tags;
 
         if (permalink)
             file.l = permalink;
@@ -61,6 +62,23 @@ files.processFiles(dirpath, extension, null, subdirs,
 
         words.collectWords(result, cwords, filesdes.length - 1);
     });
+
+function stripOuterQuotes(str) {
+    if (typeof str !== 'string') {
+        return str;
+    }
+    const lastCharIdx = str.length - 1;
+    if (
+          (str.charAt(0) === "'" &&
+          str.charAt(lastCharIdx) === "'") ||
+          (str.charAt(0) === '"' &&
+          str.charAt(lastCharIdx) === '"')
+    ) {
+        return str.slice(1, lastCharIdx);
+    } else {
+        return str;
+    }
+}
 
 fs.writeFileSync('files.json', JSON.stringify(filesdes));
 fs.writeFileSync('index.json', JSON.stringify(result));

--- a/Indexer/lib/files.js
+++ b/Indexer/lib/files.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 
-function processFiles(dirpath, extension, prefix, subdirs, fn) {
+function processFiles(dirpath, extension, prefix, subdirs, fn, currentRelativeDir = '') {
     const filenames = fs.readdirSync(dirpath);
     const l = filenames.length;
 
@@ -29,17 +29,18 @@ function processFiles(dirpath, extension, prefix, subdirs, fn) {
         if (stat.isDirectory()) {
             const newprefix = prefix ? path.join(prefix, filename) : filename;
             const newdirpath = path.join(dirpath, filename);
+            const nextRelativeDir = path.join(currentRelativeDir, filename);
             let shouldRecur;
             if (subdirs.length > 0) {
                 shouldRecur = subdirs.filter((subdir) => (
-                    // recursively track subdir/ this is more of a brute force approach
-                    newdirpath.indexOf(subdir) >= 0
+                    (subdir.startsWith(nextRelativeDir)) ||
+                    (nextRelativeDir.startsWith(subdir))
                 )).length > 0;
             } else {
                 shouldRecur = true;
             }
             if (shouldRecur) {
-                processFiles(newdirpath, extension, newprefix, subdirs, fn);
+                processFiles(newdirpath, extension, newprefix, subdirs, fn, nextRelativeDir);
             }
         }
     }

--- a/Indexer/lib/files.js
+++ b/Indexer/lib/files.js
@@ -2,36 +2,47 @@
 const fs = require('fs');
 const path = require('path');
 
-function processFiles(dirpath, extension, prefix, fn) {
+function processFiles(dirpath, extension, prefix, subdirs, fn) {
     const filenames = fs.readdirSync(dirpath);
     const l = filenames.length;
 
     for (let k = 0; k < l; k++) {
         const filename = filenames[k];
-        
+
         if (filename === 'node_modules')
             continue;
         if (filename.toLowerCase() === 'readme.md')
             continue;
         if (filename === '.github')
             continue;
-            
+
         const filepath = path.join(dirpath,  filenames[k]);
-        
+
         const stat = fs.lstatSync(filepath);
-        
+
         if (stat.isFile() && filename.endsWith(extension)) {
             const name = prefix ? path.join(prefix, filename) : filename;
             fn(name);
             continue;
         }
-        
+
         if (stat.isDirectory()) {
             const newprefix = prefix ? path.join(prefix, filename) : filename;
             const newdirpath = path.join(dirpath, filename);
-            processFiles(newdirpath, extension, newprefix, fn);
+            let shouldRecur;
+            if (subdirs.length > 0) {
+                shouldRecur = subdirs.filter((subdir) => (
+                    // recursively track subdir/ this is more of a brute force approach
+                    newdirpath.indexOf(subdir) >= 0
+                )).length > 0;
+            } else {
+                shouldRecur = true;
+            }
+            if (shouldRecur) {
+                processFiles(newdirpath, extension, newprefix, subdirs, fn);
+            }
         }
-    }    
+    }
 }
 
 module.exports = {

--- a/Indexer/pruneindex.js
+++ b/Indexer/pruneindex.js
@@ -20,58 +20,62 @@ catch (ex) {
     included = [];
 }
 
-simpleargs.define('ml','maxlen',0,'Maximum Length');
-simpleargs.define('mc','mincount',0,'Minimum Count');
-simpleargs.define('s','subword',0,'Subword');
+simpleargs.define('ml','minlen',0,'Minimum Length');
+simpleargs.define('mc','maxcount',0,'Maximum Count');
+simpleargs.define('s','subword','','Subword');
 
 const args = simpleargs(process.argv.slice(2));
 
-const maxlen = args.maxlen;
-const mincount = args.mincount;
+const minlen = args.minlen;
+const maxcount = args.maxcount;
 const subword = args.subword;
-    
+
+const hasMinlen = typeof minlen === 'number' && minlen > 0;
+const hasMaxcount = typeof maxcount === 'number' && maxcount > 0;
+const hasSubword = typeof subword === 'string' && subword.length > 0;
+
 const newindex = {};
 
 for (let word in index) {
-    if (subword && word.indexOf(subword) < 0) {
+    if (hasSubword && word.indexOf(subword) < 0) {
         newindex[word] = index[word];
-        
+
         continue;
     }
-        
+
     if (included.indexOf(word) >= 0) {
         newindex[word] = index[word];
-        
+
         continue;
     }
-        
-    if (maxlen && word.length <= maxlen) {
+
+    if (hasMinlen && word.length <= minlen) {
         toPrune(word);
 
         continue;
     }
-        
+
     const data = index[word];
     const npages = Object.keys(data).length;
-    
-    if (mincount && npages >= mincount) {
+
+    if (hasMaxcount && npages >= maxcount) {
         toPrune(word);
 
         continue;
     }
-        
+
     newindex[word] = index[word];
 }
 
 function toPrune(word) {
     console.log('pruning', word);
-    
+
     if (pruned.indexOf(word) >= 0)
         return;
-        
+
     pruned.push(word);
 }
 
 fs.writeFileSync('./pruned.json', JSON.stringify(pruned));
-    
+
 fs.writeFileSync('./index.json', JSON.stringify(newindex));


### PR DESCRIPTION
## What 

- use `\n` instead of ` ` as separator for tags
- also strip outer quotes (`"` and `'`) from titles and descriptions

## Why

- consumer of `files.json` needs to have a method to separate tags from description
- the surrounding quotes are artefacts of YAML syntax, and may be removed as noise

## Refs

- nil
- TODO consider outputting a separate `tags.json` as a file size optimisation
- TODO consider using a YAML parser lib for front matter, and restricting the scope of the current parser to the body text
- TODO no tests were added

